### PR TITLE
[TEC-3443] Adding sku to product's data shown within Sort Product page

### DIFF
--- a/app/views/spree/admin/taxons/sort_products.html.erb
+++ b/app/views/spree/admin/taxons/sort_products.html.erb
@@ -29,6 +29,7 @@
           <% product_name = product.name.split(" ") %>
           <% product_name.delete(product_name.last) %>
           <h5><%= product_name.join(" ") %></h5>
+          <h6><%= product.sku %></h6>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
### What problem is the code solving?
Showing the sku for each product when sorting them will help differentiate between the different versions. 

### How does this change address the problem?
Simply adds a new h6 tag to show the sku right below the products' name.

### Share the knowledge
Example view of the Sort Product page with the new tag:
![Screenshot from 2020-07-24 17-43-26](https://user-images.githubusercontent.com/1608166/88434114-dc8a4a00-cdd5-11ea-8daa-f1fcc1c3f802.png)
